### PR TITLE
QWebChannel: Assign class variables in constructor

### DIFF
--- a/pywebchannel/qwebchannel.py
+++ b/pywebchannel/qwebchannel.py
@@ -31,6 +31,9 @@ class QWebChannel(object):
     def __init__(self, initCallback=None):
         self.initCallback = initCallback
         self.__initialized = False
+        self.objects = {}
+        self.execCallbacks = {};
+        self.execId = 0;
 
     def initialized(self):
         self.__initialized = True
@@ -81,9 +84,6 @@ class QWebChannel(object):
         else:
             print("invalid message received: ", data)
 
-    execCallbacks = {};
-    execId = 0;
-
     def exec_(self, data, callback=None):
         if not callback:
             # if no callback is given, send directly
@@ -103,8 +103,6 @@ class QWebChannel(object):
         self.execCallbacks[data["id"]] = callback;
 
         self.send(data);
-
-    objects = {}
 
     def handleSignal(self, message):
         object = self.objects.get(message["object"], None);

--- a/pywebchannel/qwebchannel.py
+++ b/pywebchannel/qwebchannel.py
@@ -23,8 +23,6 @@ class QWebChannelMessageTypes(enum.IntEnum):
 
 class QWebChannel(object):
 
-    initCallback = None
-
     # set to QObject further down
     QObjectType = None
 
@@ -32,8 +30,8 @@ class QWebChannel(object):
         self.initCallback = initCallback
         self.__initialized = False
         self.objects = {}
-        self.execCallbacks = {};
-        self.execId = 0;
+        self.execCallbacks = {}
+        self.execId = 0
 
     def initialized(self):
         self.__initialized = True


### PR DESCRIPTION
Instead of defining class variables in the class body, assign them in the constructor to be sure they are actually new objects and not the old objects from the previous (first) run.